### PR TITLE
Compound variable names rule

### DIFF
--- a/rails/README.md
+++ b/rails/README.md
@@ -30,6 +30,7 @@
   environment variables are detected on deploy.
 - Use `includes` when you need to use data from associated tables (eager loading) [Example](/rails/sample.rb#L9)
 - Use `joins` when you need only the associated tables data to some sort of filter (lazy loading) [Example](/rails/sample.rb#L16)
+- Don't pluralize the first word in a compound variable name [Example](/rails/sample.rb#L22)
 
 # DDD
 

--- a/rails/sample.rb
+++ b/rails/sample.rb
@@ -18,3 +18,9 @@ users.each do |user|
   puts "Name: #{user.name}"
   puts "Address: #{user.address}"
 end
+
+# bad
+invoices_ids
+invoices_id
+# good
+invoice_ids


### PR DESCRIPTION
Não colocar a primeira palavra de uma variável de nome composto no plural.